### PR TITLE
Améliorer l'affichage des soumissions dans l'interface

### DIFF
--- a/pyconfr/proposals/admin.py
+++ b/pyconfr/proposals/admin.py
@@ -3,6 +3,13 @@ from django.contrib import admin
 from pyconfr.proposals.models import TalkProposal, TutorialProposal, PosterProposal
 
 
+class ProposalAdmin(admin.ModelAdmin):
+    list_display = (
+        'title',
+        'speaker'
+    )
+
+
 admin.site.register(TalkProposal)
 admin.site.register(TutorialProposal)
-admin.site.register(PosterProposal)
+admin.site.register(PosterProposal, ProposalAdmin)

--- a/pyconfr/proposals/models.py
+++ b/pyconfr/proposals/models.py
@@ -4,26 +4,29 @@ from symposion.proposals.models import ProposalBase
 
 
 class Proposal(ProposalBase):
-    
+
     AUDIENCE_LEVEL_NOVICE = 1
     AUDIENCE_LEVEL_EXPERIENCED = 2
     AUDIENCE_LEVEL_INTERMEDIATE = 3
-    
+
     AUDIENCE_LEVELS = [
         (AUDIENCE_LEVEL_NOVICE, "Novice"),
         (AUDIENCE_LEVEL_INTERMEDIATE, "Intermediate"),
         (AUDIENCE_LEVEL_EXPERIENCED, "Experienced"),
     ]
-    
+
     audience_level = models.IntegerField(choices=AUDIENCE_LEVELS)
-    
+
     recording_release = models.BooleanField(
         default=True,
         help_text="By submitting your talk proposal, you agree to give permission to the conference organizers to record, edit, and release audio and/or video of your presentation. If you do not agree to this, please uncheck this box."
     )
-    
+
     class Meta:
         abstract = True
+
+    def __unicode__(self):
+        return self.title
 
 
 class TalkProposal(Proposal):


### PR DESCRIPTION
Modification qui permet d'afficher le titre et le nom de l'auteur dans les listes de soumittion (Poster, Talk et Tutorial) et ajout de "Proposal.**unicode**()" afin d'avoir un affichage plus explicite que "PosterProposal object".
